### PR TITLE
Add 3DConnexion Spacepilot quirks

### DIFF
--- a/firmware/src/quirks.cc
+++ b/firmware/src/quirks.cc
@@ -21,8 +21,10 @@ const uint16_t VENDOR_ID_CH_PRODUCTS = 0x068e;
 const uint16_t PRODUCT_ID_CH_PRODUCTS_DT225 = 0xf700;
 
 const uint16_t VENDOR_ID_3DCONNEXION = 0x256f;
+const uint16_t VENDOR_ID_LOGITECH = 0x046D;
 const uint16_t PRODUCT_ID_3DCONNEXION_SPACEMOUSE_COMPACT = 0xc635;
 const uint16_t PRODUCT_ID_3DCONNEXION_SPACEMOUSE_PRO = 0xc62b;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACEPILOT = 0xc625;
 
 const uint8_t elecom_huge_descriptor[] = {
     0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
@@ -605,6 +607,157 @@ const uint8_t spacemouse_pro_descriptor[] = {
     0xC0,              // End Collection
 };
 
+const uint8_t spacepilot_descriptor[] = {
+    0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
+    0x09, 0x08,        // Usage (Multi-axis Controller)
+    0xA1, 0x01,        // Collection (Application)
+    0xA1, 0x00,        //   Collection (Physical)
+    0x85, 0x01,        //     Report ID (1)
+    0x16, 0x0C, 0xFE,  //     Logical Minimum (-500)
+    0x26, 0xF4, 0x01,  //     Logical Maximum (500)
+    0x36, 0x00, 0x80,  //     Physical Minimum (-32768)
+    0x46, 0xFF, 0x7F,  //     Physical Maximum (32767)
+    0x09, 0x30,        //     Usage (X)
+    0x09, 0x31,        //     Usage (Y)
+    0x09, 0x32,        //     Usage (Z)
+    0x75, 0x10,        //     Report Size (16)
+    0x95, 0x03,        //     Report Count (3)
+    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              //   End Collection
+    0xA1, 0x00,        //   Collection (Physical)
+    0x85, 0x02,        //     Report ID (2)
+    0x09, 0x33,        //     Usage (Rx)
+    0x09, 0x34,        //     Usage (Ry)
+    0x09, 0x35,        //     Usage (Rz)
+    0x75, 0x10,        //     Report Size (16)
+    0x95, 0x03,        //     Report Count (3)
+    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              //   End Collection
+    0xA1, 0x02,        //   Collection (Logical)
+    0x85, 0x03,        //     Report ID (3)
+    0x05, 0x01,        //     Usage Page (Generic Desktop Ctrls)
+    0x05, 0x09,        //     Usage Page (Button)
+    0x19, 0x01,        //     Usage Minimum (0x01)
+    0x29, 0x15,        //     Usage Maximum (0x15)
+    0x15, 0x00,        //     Logical Minimum (0)
+    0x25, 0x01,        //     Logical Maximum (1)
+    0x35, 0x00,        //     Physical Minimum (0)
+    0x45, 0x01,        //     Physical Maximum (1)
+    0x75, 0x01,        //     Report Size (1)
+    0x95, 0x15,        //     Report Count (21)
+    0x81, 0x02,        //     Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x95, 0x03,        //     Report Count (3)
+    0x81, 0x03,        //     Input (Const,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              //   End Collection
+    0xA1, 0x02,        //   Collection (Logical)
+    0x85, 0x04,        //     Report ID (4)
+    0x05, 0x08,        //     Usage Page (LEDs)
+    0x19, 0x4B,        //     Usage Minimum (Generic Indicator)
+    0x29, 0x4E,        //     Usage Maximum (0x4E)
+    0x15, 0x00,        //     Logical Minimum (0)
+    0x25, 0x01,        //     Logical Maximum (1)
+    0x95, 0x04,        //     Report Count (4)
+    0x75, 0x01,        //     Report Size (1)
+    0x91, 0x02,        //     Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x95, 0x01,        //     Report Count (1)
+    0x75, 0x04,        //     Report Size (4)
+    0x91, 0x03,        //     Output (Const,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //   End Collection
+    0x06, 0x00, 0xFF,  //   Usage Page (Vendor Defined 0xFF00)
+    0x09, 0x01,        //   Usage (0x01)
+    0xA1, 0x02,        //   Collection (Logical)
+    0x15, 0x80,        //     Logical Minimum (-128)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x09, 0x3A,        //     Usage (0x3A)
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x05,        //       Report ID (5)
+    0x09, 0x20,        //       Usage (0x20)
+    0x95, 0x01,        //       Report Count (1)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x06,        //       Report ID (6)
+    0x09, 0x21,        //       Usage (0x21)
+    0x95, 0x01,        //       Report Count (1)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x07,        //       Report ID (7)
+    0x09, 0x22,        //       Usage (0x22)
+    0x95, 0x01,        //       Report Count (1)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x08,        //       Report ID (8)
+    0x09, 0x23,        //       Usage (0x23)
+    0x95, 0x07,        //       Report Count (7)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x09,        //       Report ID (9)
+    0x09, 0x24,        //       Usage (0x24)
+    0x95, 0x07,        //       Report Count (7)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x0A,        //       Report ID (10)
+    0x09, 0x25,        //       Usage (0x25)
+    0x95, 0x07,        //       Report Count (7)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x0B,        //       Report ID (11)
+    0x09, 0x26,        //       Usage (0x26)
+    0x95, 0x01,        //       Report Count (1)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x0C,        //       Report ID (12)
+    0x09, 0x27,        //       Usage (0x27)
+    0x95, 0x03,        //       Report Count (3)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x0D,        //       Report ID (13)
+    0x09, 0x28,        //       Usage (0x28)
+    0x95, 0x07,        //       Report Count (7)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x0E,        //       Report ID (14)
+    0x09, 0x29,        //       Usage (0x29)
+    0x95, 0x06,        //       Report Count (6)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x0F,        //       Report ID (15)
+    0x09, 0x2A,        //       Usage (0x2A)
+    0x95, 0x01,        //       Report Count (1)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x10,        //       Report ID (16)
+    0x09, 0x2C,        //       Usage (0x2C)
+    0x95, 0x01,        //       Report Count (1)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x11,        //       Report ID (17)
+    0x09, 0x2C,        //       Usage (0x2C)
+    0x95, 0x01,        //       Report Count (1)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x12,        //       Report ID (18)
+    0x09, 0x2B,        //       Usage (0x2B)
+    0x95, 0x06,        //       Report Count (6)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xC0,              //   End Collection
+    0xC0,              // End Collection
+};
+
 void apply_quirks(uint16_t vendor_id, uint16_t product_id, std::unordered_map<uint8_t, std::unordered_map<uint32_t, usage_def_t>>& usage_map, const uint8_t* report_descriptor, int len, uint8_t itf_num) {
     // Button Fn1 is described as a constant (padding) in the descriptor.
     // We add it as button 6.
@@ -734,19 +887,24 @@ void apply_quirks(uint16_t vendor_id, uint16_t product_id, std::unordered_map<ui
     }
 
     // SpaceMouse says its usages are relative, but they're not.
-    if (vendor_id == VENDOR_ID_3DCONNEXION &&
+    if ((vendor_id == VENDOR_ID_3DCONNEXION &&
         ((product_id == PRODUCT_ID_3DCONNEXION_SPACEMOUSE_COMPACT &&
-             len == sizeof(spacemouse_compact_descriptor) &&
-             !memcmp(report_descriptor, spacemouse_compact_descriptor, len)) ||
-            (product_id == PRODUCT_ID_3DCONNEXION_SPACEMOUSE_PRO &&
-                len == sizeof(spacemouse_pro_descriptor) &&
-                !memcmp(report_descriptor, spacemouse_pro_descriptor, len)))) {
-        usage_map[1][0x00010030].is_relative = false;
-        usage_map[1][0x00010031].is_relative = false;
-        usage_map[1][0x00010032].is_relative = false;
-        usage_map[2][0x00010033].is_relative = false;
-        usage_map[2][0x00010034].is_relative = false;
-        usage_map[2][0x00010035].is_relative = false;
+            len == sizeof(spacemouse_compact_descriptor) &&
+            !memcmp(report_descriptor, spacemouse_compact_descriptor, len)) ||
+          (product_id == PRODUCT_ID_3DCONNEXION_SPACEMOUSE_PRO &&
+            len == sizeof(spacemouse_pro_descriptor) &&
+            !memcmp(report_descriptor, spacemouse_pro_descriptor, len))
+        )
+      ) || (vendor_id == VENDOR_ID_LOGITECH &&
+        ((product_id == PRODUCT_ID_3DCONNEXION_SPACEPILOT &&
+          len == sizeof(spacepilot_descriptor) &&
+          !memcmp(report_descriptor, spacepilot_descriptor, len))))) {
+      usage_map[1][0x00010030].is_relative = false;
+      usage_map[1][0x00010031].is_relative = false;
+      usage_map[1][0x00010032].is_relative = false;
+      usage_map[2][0x00010033].is_relative = false;
+      usage_map[2][0x00010034].is_relative = false;
+      usage_map[2][0x00010035].is_relative = false;
     }
 
     // apply user-defined quirks


### PR DESCRIPTION
Added the quirk for the SpacePilot Device to the Quirks forllowing the format of previous devices.
Using VID, PID & descriptor from the device in question.

Works to add support for HID from #250 