### PR TITLE
Quirks for Elecom HUGE PLUS trackball

### DIFF
--- a/firmware/src/quirks.cc
+++ b/firmware/src/quirks.cc
@@ -14,6 +14,8 @@ const uint16_t PRODUCT_ID_ELECOM_M_DT1DRBK = 0x00ff;
 const uint16_t PRODUCT_ID_ELECOM_M_HT1URBK = 0x010c;
 const uint16_t PRODUCT_ID_ELECOM_M_HT1DRBK_010D = 0x010d;
 const uint16_t PRODUCT_ID_ELECOM_M_HT1DRBK_011C = 0x011c;
+const uint16_t PRODUCT_ID_ELECOM_M_HT1MRBK_01AA = 0x01aa;
+const uint16_t PRODUCT_ID_ELECOM_M_HT1MRBK_01AB = 0x01ab;
 
 const uint16_t VENDOR_ID_KENSINGTON = 0x047d;
 const uint16_t PRODUCT_ID_KENSINGTON_SLIMBLADE = 0x2041;
@@ -242,6 +244,204 @@ const uint8_t elecom_huge_descriptor2[] = {
     0x26, 0xFF, 0x00,  //   Logical Maximum (255)
     0x75, 0x08,        //   Report Size (8)
     0x95, 0x07,        //   Report Count (7)
+    0xB1, 0x02,        //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              // End Collection
+};
+
+// Elecom Huge Plus wired, 056e:01aa
+const uint8_t elecom_huge_plus_01aa_descriptor[] = {
+    0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
+    0x09, 0x02,        // Usage (Mouse)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x01,        //   Report ID (1)
+    0x09, 0x01,        //   Usage (Pointer)
+    0xA1, 0x00,        //   Collection (Physical)
+    0x05, 0x09,        //     Usage Page (Button)
+    0x19, 0x01,        //     Usage Minimum (0x01)
+    0x29, 0x05,        //     Usage Maximum (0x05)
+    0x15, 0x00,        //     Logical Minimum (0)
+    0x25, 0x01,        //     Logical Maximum (1)
+    0x75, 0x01,        //     Report Size (1)
+    0x95, 0x05,        //     Report Count (5)
+    0x81, 0x02,        //     Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x75, 0x03,        //     Report Size (3)
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x01,        //     Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x05, 0x01,        //     Usage Page (Generic Desktop Ctrls)
+    0x09, 0x30,        //     Usage (X)
+    0x09, 0x31,        //     Usage (Y)
+    0x16, 0x01, 0x80,  //     Logical Minimum (-32767)
+    0x26, 0xFF, 0x7F,  //     Logical Maximum (32767)
+    0x75, 0x10,        //     Report Size (16)
+    0x95, 0x02,        //     Report Count (2)
+    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+    0x09, 0x38,        //     Usage (Wheel)
+    0x15, 0x81,        //     Logical Minimum (-127)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+    0x05, 0x0C,        //     Usage Page (Consumer)
+    0x0A, 0x38, 0x02,  //     Usage (AC Pan)
+    0x15, 0x81,        //     Logical Minimum (-127)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              //   End Collection
+    0xC0,              // End Collection
+    0x05, 0x0C,        // Usage Page (Consumer)
+    0x09, 0x01,        // Usage (Consumer Control)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x02,        //   Report ID (2)
+    0x15, 0x01,        //   Logical Minimum (1)
+    0x26, 0x8C, 0x02,  //   Logical Maximum (652)
+    0x19, 0x01,        //   Usage Minimum (Consumer Control)
+    0x2A, 0x8C, 0x02,  //   Usage Maximum (AC Send)
+    0x75, 0x10,        //   Report Size (16)
+    0x95, 0x01,        //   Report Count (1)
+    0x81, 0x00,        //   Input (Data,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              // End Collection
+    0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
+    0x09, 0x80,        // Usage (Sys Control)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x03,        //   Report ID (3)
+    0x09, 0x82,        //   Usage (Sys Sleep)
+    0x09, 0x81,        //   Usage (Sys Power Down)
+    0x09, 0x83,        //   Usage (Sys Wake Up)
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x25, 0x01,        //   Logical Maximum (1)
+    0x19, 0x01,        //   Usage Minimum (Pointer)
+    0x29, 0x03,        //   Usage Maximum (0x03)
+    0x75, 0x01,        //   Report Size (1)
+    0x95, 0x03,        //   Report Count (3)
+    0x81, 0x02,        //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x95, 0x05,        //   Report Count (5)
+    0x81, 0x01,        //   Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              // End Collection
+    0x06, 0x01, 0xFF,  // Usage Page (Vendor Defined 0xFF01)
+    0x09, 0x00,        // Usage (0x00)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x08,        //   Report ID (8)
+    0x09, 0x00,        //   Usage (0x00)
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+    0x75, 0x08,        //   Report Size (8)
+    0x95, 0x07,        //   Report Count (7)
+    0x81, 0x02,        //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              // End Collection
+    0x06, 0x02, 0xFF,  // Usage Page (Vendor Defined 0xFF02)
+    0x09, 0x02,        // Usage (0x02)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x06,        //   Report ID (6)
+    0x09, 0x02,        //   Usage (0x02)
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+    0x75, 0x08,        //   Report Size (8)
+    0x95, 0x07,        //   Report Count (7)
+    0xB1, 0x02,        //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              // End Collection
+};
+
+// Elecom Huge Plus wireless, 056e:01ab
+const uint8_t elecom_huge_plus_01ab_descriptor[] = {
+    0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
+    0x09, 0x02,        // Usage (Mouse)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x01,        //   Report ID (1)
+    0x09, 0x01,        //   Usage (Pointer)
+    0xA1, 0x00,        //   Collection (Physical)
+    0x05, 0x09,        //     Usage Page (Button)
+    0x19, 0x01,        //     Usage Minimum (0x01)
+    0x29, 0x05,        //     Usage Maximum (0x05)
+    0x15, 0x00,        //     Logical Minimum (0)
+    0x25, 0x01,        //     Logical Maximum (1)
+    0x75, 0x01,        //     Report Size (1)
+    0x95, 0x05,        //     Report Count (5)
+    0x81, 0x02,        //     Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x75, 0x03,        //     Report Size (3)
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x01,        //     Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x05, 0x01,        //     Usage Page (Generic Desktop Ctrls)
+    0x09, 0x30,        //     Usage (X)
+    0x09, 0x31,        //     Usage (Y)
+    0x16, 0x01, 0x80,  //     Logical Minimum (-32767)
+    0x26, 0xFF, 0x7F,  //     Logical Maximum (32767)
+    0x75, 0x10,        //     Report Size (16)
+    0x95, 0x02,        //     Report Count (2)
+    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+    0x09, 0x38,        //     Usage (Wheel)
+    0x15, 0x81,        //     Logical Minimum (-127)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+    0x05, 0x0C,        //     Usage Page (Consumer)
+    0x0A, 0x38, 0x02,  //     Usage (AC Pan)
+    0x15, 0x81,        //     Logical Minimum (-127)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              //   End Collection
+    0xC0,              // End Collection
+    0x05, 0x0C,        // Usage Page (Consumer)
+    0x09, 0x01,        // Usage (Consumer Control)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x02,        //   Report ID (2)
+    0x75, 0x10,        //   Report Size (16)
+    0x95, 0x01,        //   Report Count (1)
+    0x15, 0x01,        //   Logical Minimum (1)
+    0x26, 0x8C, 0x02,  //   Logical Maximum (652)
+    0x19, 0x01,        //   Usage Minimum (Consumer Control)
+    0x2A, 0x8C, 0x02,  //   Usage Maximum (AC Send)
+    0x81, 0x00,        //   Input (Data,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              // End Collection
+    0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
+    0x09, 0x80,        // Usage (Sys Control)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x03,        //   Report ID (3)
+    0x09, 0x82,        //   Usage (Sys Sleep)
+    0x09, 0x81,        //   Usage (Sys Power Down)
+    0x09, 0x83,        //   Usage (Sys Wake Up)
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x25, 0x01,        //   Logical Maximum (1)
+    0x19, 0x01,        //   Usage Minimum (Pointer)
+    0x29, 0x03,        //   Usage Maximum (0x03)
+    0x75, 0x01,        //   Report Size (1)
+    0x95, 0x03,        //   Report Count (3)
+    0x81, 0x02,        //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x95, 0x05,        //   Report Count (5)
+    0x81, 0x01,        //   Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              // End Collection
+    0x06, 0x00, 0xFF,  // Usage Page (Vendor Defined 0xFF00)
+    0x09, 0x00,        // Usage (0x00)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x05,        //   Report ID (5)
+    0x09, 0x00,        //   Usage (0x00)
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+    0x75, 0x08,        //   Report Size (8)
+    0x95, 0x07,        //   Report Count (7)
+    0x81, 0x02,        //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x09, 0x01,        //   Usage (0x01)
+    0x91, 0x02,        //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x09, 0x02,        //   Usage (0x02)
+    0xB1, 0x02,        //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              // End Collection
+    0x06, 0x01, 0xFF,  // Usage Page (Vendor Defined 0xFF01)
+    0x09, 0x00,        // Usage (0x00)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x04,        //   Report ID (4)
+    0x09, 0x01,        //   Usage (0x01)
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+    0x75, 0x08,        //   Report Size (8)
+    0x95, 0x07,        //   Report Count (7)
+    0x81, 0x02,        //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x09, 0x01,        //   Usage (0x01)
+    0x91, 0x02,        //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x09, 0x02,        //   Usage (0x02)
     0xB1, 0x02,        //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
     0xC0,              // End Collection
 };
@@ -719,6 +919,62 @@ void apply_quirks(uint16_t vendor_id, uint16_t product_id, std::unordered_map<ui
         product_id == PRODUCT_ID_ELECOM_M_HT1DRBK_011C &&
         len == sizeof(elecom_huge_descriptor2) &&
         !memcmp(report_descriptor, elecom_huge_descriptor2, len)) {
+        usage_map[1][0x00090006] = (usage_def_t){
+            .report_id = 1,
+            .size = 1,
+            .bitpos = 5,
+            .is_relative = false,
+            .logical_minimum = 0,
+        };
+        usage_map[1][0x00090007] = (usage_def_t){
+            .report_id = 1,
+            .size = 1,
+            .bitpos = 6,
+            .is_relative = false,
+            .logical_minimum = 0,
+        };
+        usage_map[1][0x00090008] = (usage_def_t){
+            .report_id = 1,
+            .size = 1,
+            .bitpos = 7,
+            .is_relative = false,
+            .logical_minimum = 0,
+        };
+    }
+
+    // Buttons Fn1, Fn2, Fn3 don't work because Usage Maximum=5 when it should be 8
+    if (vendor_id == VENDOR_ID_ELECOM &&
+        product_id == PRODUCT_ID_ELECOM_M_HT1MRBK_01AA &&
+        len == sizeof(elecom_huge_plus_01aa_descriptor) &&
+        !memcmp(report_descriptor, elecom_huge_plus_01aa_descriptor, len)) {
+        usage_map[1][0x00090006] = (usage_def_t){
+            .report_id = 1,
+            .size = 1,
+            .bitpos = 5,
+            .is_relative = false,
+            .logical_minimum = 0,
+        };
+        usage_map[1][0x00090007] = (usage_def_t){
+            .report_id = 1,
+            .size = 1,
+            .bitpos = 6,
+            .is_relative = false,
+            .logical_minimum = 0,
+        };
+        usage_map[1][0x00090008] = (usage_def_t){
+            .report_id = 1,
+            .size = 1,
+            .bitpos = 7,
+            .is_relative = false,
+            .logical_minimum = 0,
+        };
+    }
+
+    // Buttons Fn1, Fn2, Fn3 don't work because Usage Maximum=5 when it should be 8
+    if (vendor_id == VENDOR_ID_ELECOM &&
+        product_id == PRODUCT_ID_ELECOM_M_HT1MRBK_01AB &&
+        len == sizeof(elecom_huge_plus_01ab_descriptor) &&
+        !memcmp(report_descriptor, elecom_huge_plus_01ab_descriptor, len)) {
         usage_map[1][0x00090006] = (usage_def_t){
             .report_id = 1,
             .size = 1,


### PR DESCRIPTION
This pull request adds support for the additional function buttons (Fn1, Fn2, Fn3) on the Elecom HUGE PLUS trackball.

Elecom HUGE PLUS M_HT1MRBK (Wired)
Vendor/Product ID: 056e:01AA — Fn1, Fn2, and Fn3 are now supported.

Elecom HUGE PLUS M_HT1MRBK (Wireless)
Vendor/Product ID: 056e:01AB — Fn1, Fn2, and Fn3 are now supported as well.