### PR TITLE
Space pilot to space mouse pro (Draft)

### DIFF
--- a/config-tool-web/examples.js
+++ b/config-tool-web/examples.js
@@ -10066,6 +10066,279 @@ const examples = [
             ],
             "quirks": []
         }
+    },
+    {
+        'description': 'SpacePilot to SpaceMouse Pro',
+        'config': {
+            "version": 15,
+            "unmapped_passthrough_layers": [],
+            "partial_scroll_timeout": 1000000,
+            "tap_hold_threshold": 200000,
+            "gpio_debounce_time_ms": 5,
+            "interval_override": 0,
+            "our_descriptor_number": 6,
+            "ignore_auth_dev_inputs": false,
+            "macro_entry_duration": 1,
+            "gpio_output_mode": 0,
+            "input_labels": 0,
+            "mappings": [
+                {
+                    "source_usage": "0x00090001",
+                    "source_name": "1",
+                    "target_usage": "0x0009000d",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x00090002",
+                    "source_name": "2",
+                    "target_usage": "0x0009000e",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x00090003",
+                    "source_name": "3",
+                    "target_usage": "0x0009000f",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x00090004",
+                    "source_name": "4",
+                    "target_usage": "0x00090010",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x00090007",
+                    "source_name": "T",
+                    "target_usage": "0x00090003",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x00090009",
+                    "source_name": "R",
+                    "target_usage": "0x00090005",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x0009000a",
+                    "source_name": "F",
+                    "target_usage": "0x00090006",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x00090008",
+                    "source_name": "L",
+                    "target_usage": "0x00090009",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x0009000f",
+                    "source_name": "Fit",
+                    "target_usage": "0x00090002",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x00090015",
+                    "source_name": "Config",
+                    "target_usage": "0x00090001",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x0009000b",
+                    "source_name": "Escape",
+                    "target_usage": "0x00090017",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x0009000c",
+                    "source_name": "Alt",
+                    "target_usage": "0x00090018",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x0009000d",
+                    "source_name": "Shift",
+                    "target_usage": "0x00090019",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x0009000e",
+                    "source_name": "Control",
+                    "target_usage": "0x0009001a",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                },
+                {
+                    "source_usage": "0x00090014",
+                    "source_name": "Rotation toggle",
+                    "target_usage": "0x0009001b",
+                    "scaling": 1000,
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "tap": false,
+                    "hold": false,
+                    "source_port": 0,
+                    "target_port": 0
+                }
+            ],
+            "macros": [
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                []
+            ],
+            "expressions": [
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                ""
+            ],
+            "quirks": []
+        }
     }
 ];
 

--- a/config-tool-web/examples.js
+++ b/config-tool-web/examples.js
@@ -10291,6 +10291,66 @@ const examples = [
                     "hold": false,
                     "source_port": 0,
                     "target_port": 0
+                },
+                {
+                    "source_usage": "0x00010030",
+                    "source_name": "Axis X",
+                    "target_usage": "0x00010030",
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "scaling": 1000
+                },
+                {
+                    "source_usage": "0x00010031",
+                    "source_name": "Axis Y",
+                    "target_usage": "0x00010031",
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "scaling": 1000
+                },
+                {
+                    "source_usage": "0x00010032",
+                    "source_name": "Axis Z",
+                    "target_usage": "0x00010032",
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "scaling": 1000
+                },
+                {
+                    "source_usage": "0x00010033",
+                    "source_name": "Axis RX",
+                    "target_usage": "0x00010033",
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "scaling": 1000
+                },
+                {
+                    "source_usage": "0x00010034",
+                    "source_name": "Axis RY",
+                    "target_usage": "0x00010034",
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "scaling": 1000
+                },
+                {
+                    "source_usage": "0x00010035",
+                    "source_name": "Axis RZ",
+                    "target_usage": "0x00010035",
+                    "layers": [
+                        0
+                    ],
+                    "sticky": false,
+                    "scaling": 1000
                 }
             ],
             "macros": [

--- a/config-tool-web/index.html
+++ b/config-tool-web/index.html
@@ -186,6 +186,7 @@
                             <option value="3">PS4 arcade stick</option>
                             <option value="4">Stadia controller</option>
                             <option value="5">XAC/Flex compatible</option>
+                            <option value="6">SpaceMouse Pro</option>
                         </select>
                     </div>
                 </div>

--- a/config-tool-web/usages.js
+++ b/config-tool-web/usages.js
@@ -527,6 +527,29 @@ const usages = {
         "0x00090007": { 'name': 'View', 'class': 'mouse' },
         "0x00090008": { 'name': 'Menu', 'class': 'mouse' },
     },
+    6: {
+        "0x00010030": { 'name': 'X', 'class': 'mouse' },
+        "0x00010031": { 'name': 'Y', 'class': 'mouse' },
+        "0x00010032": { 'name': 'Z', 'class': 'mouse' },
+        "0x00010033": { 'name': 'RX', 'class': 'mouse' },
+        "0x00010034": { 'name': 'RY', 'class': 'mouse' },
+        "0x00010035": { 'name': 'RZ', 'class': 'mouse' },
+        "0x00090001": { 'name': 'Menu', 'class': 'mouse' },
+        "0x00090002": { 'name': 'Fit', 'class': 'mouse' },
+        "0x00090003": { 'name': 'Top view', 'class': 'mouse' },
+        "0x00090005": { 'name': 'Right view', 'class': 'mouse' },
+        "0x00090006": { 'name': 'Front view', 'class': 'mouse' },
+        "0x00090009": { 'name': 'Roll view', 'class': 'mouse' },
+        "0x0009000d": { 'name': '1', 'class': 'mouse' },
+        "0x0009000e": { 'name': '2', 'class': 'mouse' },
+        "0x0009000f": { 'name': '3', 'class': 'mouse' },
+        "0x00090010": { 'name': '4', 'class': 'mouse' },
+        "0x00090017": { 'name': 'Escape', 'class': 'mouse' },
+        "0x00090018": { 'name': 'Alt', 'class': 'mouse' },
+        "0x00090019": { 'name': 'Shift', 'class': 'mouse' },
+        "0x0009001a": { 'name': 'Control', 'class': 'mouse' },
+        "0x0009001b": { 'name': 'Rotation toggle', 'class': 'mouse' },
+    },
 };
 
 const common_target_usages = {
@@ -645,6 +668,7 @@ Object.assign(usages[2], common_target_usages);
 Object.assign(usages[3], common_target_usages);
 Object.assign(usages[4], common_target_usages);
 Object.assign(usages[5], common_target_usages);
+Object.assign(usages[6], common_target_usages);
 usages[1] = usages[0]; // absolute mouse & keyboard is the same as regular mouse & keyboard
 
 export default usages;

--- a/firmware/src/our_descriptor.cc
+++ b/firmware/src/our_descriptor.cc
@@ -521,6 +521,171 @@ uint8_t const our_report_descriptor_xac_compat[] = {
     0xC0,              // End Collection
 };
 
+uint8_t const our_report_descriptor_spacemouse[] = {
+    0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
+    0x09, 0x08,        // Usage (Multi-axis Controller)
+    0xA1, 0x01,        // Collection (Application)
+    0xA1, 0x00,        //   Collection (Physical)
+    0x85, 0x01,        //     Report ID (1)
+    0x16, 0xA2, 0xFE,  //     Logical Minimum (-350)
+    0x26, 0x5E, 0x01,  //     Logical Maximum (350)
+    0x36, 0x88, 0xFA,  //     Physical Minimum (-1400)
+    0x46, 0x78, 0x05,  //     Physical Maximum (1400)
+    0x55, 0x0C,        //     Unit Exponent (-4)
+    0x65, 0x11,        //     Unit (System: SI Linear, Length: Centimeter)
+    0x09, 0x30,        //     Usage (X)
+    0x09, 0x31,        //     Usage (Y)
+    0x09, 0x32,        //     Usage (Z)
+    0x75, 0x10,        //     Report Size (16)
+    0x95, 0x03,        //     Report Count (3)
+    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              //   End Collection
+    0xA1, 0x00,        //   Collection (Physical)
+    0x85, 0x02,        //     Report ID (2)
+    0x09, 0x33,        //     Usage (Rx)
+    0x09, 0x34,        //     Usage (Ry)
+    0x09, 0x35,        //     Usage (Rz)
+    0x75, 0x10,        //     Report Size (16)
+    0x95, 0x03,        //     Report Count (3)
+    0x81, 0x06,        //     Input (Data,Var,Rel,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              //   End Collection
+    0xA1, 0x02,        //   Collection (Logical)
+    0x85, 0x03,        //     Report ID (3)
+    0x05, 0x01,        //     Usage Page (Generic Desktop Ctrls)
+    0x05, 0x09,        //     Usage Page (Button)
+    0x19, 0x01,        //     Usage Minimum (0x01)
+    0x29, 0x03,        //     Usage Maximum (0x03)
+    0x15, 0x00,        //     Logical Minimum (0)
+    0x25, 0x01,        //     Logical Maximum (1)
+    0x35, 0x00,        //     Physical Minimum (0)
+    0x45, 0x01,        //     Physical Maximum (1)
+    0x75, 0x01,        //     Report Size (1)
+    0x95, 0x03,        //     Report Count (3)
+    0x81, 0x02,        //     Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x03,        //     Input (Const,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x19, 0x05,        //     Usage Minimum (0x05)
+    0x29, 0x06,        //     Usage Maximum (0x06)
+    0x95, 0x02,        //     Report Count (2)
+    0x81, 0x02,        //     Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x95, 0x02,        //     Report Count (2)
+    0x81, 0x03,        //     Input (Const,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x09, 0x09,        //     Usage (0x09)
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x02,        //     Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x95, 0x03,        //     Report Count (3)
+    0x81, 0x03,        //     Input (Const,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x19, 0x0D,        //     Usage Minimum (0x0D)
+    0x29, 0x10,        //     Usage Maximum (0x10)
+    0x95, 0x04,        //     Report Count (4)
+    0x81, 0x02,        //     Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x95, 0x06,        //     Report Count (6)
+    0x81, 0x03,        //     Input (Const,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x19, 0x17,        //     Usage Minimum (0x17)
+    0x29, 0x1B,        //     Usage Maximum (0x1B)
+    0x95, 0x05,        //     Report Count (5)
+    0x81, 0x02,        //     Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x95, 0x15,        //     Report Count (21)
+    0x81, 0x03,        //     Input (Const,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              //   End Collection
+    0xA1, 0x02,        //   Collection (Logical)
+    0x85, 0x04,        //     Report ID (4)
+    0x05, 0x08,        //     Usage Page (LEDs)
+    0x09, 0x4B,        //     Usage (Generic Indicator)
+    0x15, 0x00,        //     Logical Minimum (0)
+    0x25, 0x01,        //     Logical Maximum (1)
+    0x95, 0x01,        //     Report Count (1)
+    0x75, 0x01,        //     Report Size (1)
+    0x91, 0x02,        //     Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0x95, 0x01,        //     Report Count (1)
+    0x75, 0x07,        //     Report Size (7)
+    0x91, 0x03,        //     Output (Const,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //   End Collection
+    0x06, 0x00, 0xFF,  //   Usage Page (Vendor Defined 0xFF00)
+    0x09, 0x01,        //   Usage (0x01)
+    0xA1, 0x02,        //   Collection (Logical)
+    0x15, 0x80,        //     Logical Minimum (-128)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x09, 0x3A,        //     Usage (0x3A)
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x05,        //       Report ID (5)
+    0x09, 0x20,        //       Usage (0x20)
+    0x95, 0x01,        //       Report Count (1)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x06,        //       Report ID (6)
+    0x09, 0x21,        //       Usage (0x21)
+    0x95, 0x01,        //       Report Count (1)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x07,        //       Report ID (7)
+    0x09, 0x22,        //       Usage (0x22)
+    0x95, 0x01,        //       Report Count (1)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x08,        //       Report ID (8)
+    0x09, 0x23,        //       Usage (0x23)
+    0x95, 0x07,        //       Report Count (7)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x09,        //       Report ID (9)
+    0x09, 0x24,        //       Usage (0x24)
+    0x95, 0x07,        //       Report Count (7)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x0A,        //       Report ID (10)
+    0x09, 0x25,        //       Usage (0x25)
+    0x95, 0x07,        //       Report Count (7)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x0B,        //       Report ID (11)
+    0x09, 0x26,        //       Usage (0x26)
+    0x95, 0x01,        //       Report Count (1)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x13,        //       Report ID (19)
+    0x09, 0x2E,        //       Usage (0x2E)
+    0x95, 0x01,        //       Report Count (1)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x14,        //       Report ID (20)
+    0x09, 0x2F,        //       Usage (0x2F)
+    0x95, 0x04,        //       Report Count (4)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x15,        //       Report ID (21)
+    0x09, 0x30,        //       Usage (0x30)
+    0x95, 0x01,        //       Report Count (1)
+    0xB1, 0x02,        //       Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0,              //     End Collection
+    0xA1, 0x02,        //     Collection (Logical)
+    0x85, 0x16,        //       Report ID (22)
+    0x19, 0x01,        //       Usage Minimum (0x01)
+    0x29, 0x1F,        //       Usage Maximum (0x1F)
+    0x15, 0x00,        //       Logical Minimum (0)
+    0x25, 0x01,        //       Logical Maximum (1)
+    0x35, 0x00,        //       Physical Minimum (0)
+    0x45, 0x01,        //       Physical Maximum (1)
+    0x75, 0x01,        //       Report Size (1)
+    0x95, 0x1F,        //       Report Count (31)
+    0x81, 0x02,        //       Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x95, 0x01,        //       Report Count (1)
+    0x81, 0x03,        //       Input (Const,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0xC0,              //     End Collection
+    0xC0,              //   End Collection
+    0xC0,              // End Collection
+};
+
 void kb_mouse_handle_set_report(uint8_t report_id, const uint8_t* buffer, uint16_t reqlen) {
     if (report_id == REPORT_ID_MULTIPLIER && reqlen >= 1) {
         memcpy(&resolution_multiplier, buffer, 1);
@@ -629,6 +794,41 @@ void stadia_sanitize_report(uint8_t report_id, uint8_t* buffer, uint16_t len) {
     }
 }
 
+void needs_to_be_sent_spacemouse(uint8_t** reports, uint8_t** prev_reports, uint16_t* report_sizes, bool* reports_to_send, uint64_t frame_counter) {
+    reports_to_send[1] = false;
+    reports_to_send[2] = false;
+    reports_to_send[3] = false;
+    reports_to_send[22] = false;
+
+    // We always send 2 reports together so only send them once every 3 frames.
+    // (3, not 2, to leave space for the button report as well.)
+
+    // A real SpaceMouse also sends reports with all zeros three times when the movement
+    // stops, but it doesn't seem to make a difference.
+    // Something to consider for the future.
+
+    if (frame_counter % 3 == 0) {
+        for (int i = 1; i <= 2; i++) {
+            if (memcmp(reports[i], prev_reports[i], report_sizes[i]) != 0) {
+                reports_to_send[i] = true;
+                continue;
+            }
+            for (int j = 0; j < report_sizes[i]; j++) {
+                if (reports[i][j] != 0) {
+                    reports_to_send[i] = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    reports_to_send[1] = reports_to_send[2] = reports_to_send[1] || reports_to_send[2];
+
+    if (memcmp(reports[3], prev_reports[3], report_sizes[3]) != 0) {
+        reports_to_send[3] = true;
+    }
+}
+
 const our_descriptor_def_t our_descriptors[] = {
     {
         .idx = 0,
@@ -695,6 +895,15 @@ const our_descriptor_def_t our_descriptors[] = {
         .handle_received_report = do_handle_received_report,
         .clear_report = xac_compat_clear_report,
         .default_value = ps4_stadia_default_value,  // sic
+    },
+    {
+        .idx = 6,
+        .descriptor = our_report_descriptor_spacemouse,
+        .descriptor_length = sizeof(our_report_descriptor_spacemouse),
+        .vid = 0x046D,
+        .pid = 0xC62B,
+        .handle_received_report = do_handle_received_report,
+        .needs_to_be_sent = needs_to_be_sent_spacemouse,
     },
 };
 

--- a/firmware/src/our_descriptor.cc
+++ b/firmware/src/our_descriptor.cc
@@ -902,6 +902,8 @@ const our_descriptor_def_t our_descriptors[] = {
         .descriptor_length = sizeof(our_report_descriptor_spacemouse),
         .vid = 0x046D,
         .pid = 0xC62B,
+        .manufacturer = "3Dconnexion",
+        .product = "SpaceMouse Pro",
         .handle_received_report = do_handle_received_report,
         .needs_to_be_sent = needs_to_be_sent_spacemouse,
     },

--- a/firmware/src/our_descriptor.h
+++ b/firmware/src/our_descriptor.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#include "types.h"
+
 #define CONFIG_SIZE 32
 #define RESOLUTION_MULTIPLIER 120
 
@@ -11,9 +13,9 @@
 #define REPORT_ID_CONFIG 100
 #define REPORT_ID_MONITOR 101
 
-#define MAX_INPUT_REPORT_ID 3
+#define MAX_INPUT_REPORT_ID 22
 
-#define NOUR_DESCRIPTORS 6
+#define NOUR_DESCRIPTORS 7
 
 typedef void (*device_connected_t)(uint16_t interface, uint16_t vid, uint16_t pid);
 typedef void (*device_disconnected_t)(uint8_t dev_addr);
@@ -27,6 +29,7 @@ typedef void (*handle_set_report_complete_t)(uint16_t interface, uint8_t report_
 typedef void (*clear_report_t)(uint8_t* report, uint8_t report_id, uint16_t len);
 typedef int32_t (*default_value_t)(uint32_t usage);
 typedef void (*sanitize_report_t)(uint8_t report_id, uint8_t* buffer, uint16_t len);
+typedef void (*needs_to_be_sent_t)(uint8_t** reports, uint8_t** prev_reports, uint16_t* report_sizes, bool* report_to_be_sent, uint64_t frame_counter);
 typedef bool (*should_cause_wakeup_t)(uint8_t report_id, const uint8_t* buffer, uint16_t len);
 
 struct our_descriptor_def_t {
@@ -47,6 +50,7 @@ struct our_descriptor_def_t {
     clear_report_t clear_report = nullptr;
     default_value_t default_value = nullptr;
     sanitize_report_t sanitize_report = nullptr;
+    needs_to_be_sent_t needs_to_be_sent = nullptr;
     should_cause_wakeup_t should_cause_wakeup = nullptr;
 };
 

--- a/firmware/src/our_descriptor.h
+++ b/firmware/src/our_descriptor.h
@@ -38,6 +38,8 @@ struct our_descriptor_def_t {
     uint32_t descriptor_length;
     uint16_t vid = 0;
     uint16_t pid = 0;
+    const char* manufacturer;
+    const char* product;
     device_connected_t device_connected = nullptr;
     device_disconnected_t device_disconnected = nullptr;
     main_loop_task_t main_loop_task = nullptr;

--- a/firmware/src/quirks.cc
+++ b/firmware/src/quirks.cc
@@ -24,10 +24,24 @@ const uint16_t VENDOR_ID_CH_PRODUCTS = 0x068e;
 const uint16_t PRODUCT_ID_CH_PRODUCTS_DT225 = 0xf700;
 
 const uint16_t VENDOR_ID_3DCONNEXION = 0x256f;
-const uint16_t VENDOR_ID_LOGITECH = 0x046D;
+const uint16_t VENDOR_ID_LOGITECH = 0x046d;
 const uint16_t PRODUCT_ID_3DCONNEXION_SPACEMOUSE_COMPACT = 0xc635;
 const uint16_t PRODUCT_ID_3DCONNEXION_SPACEMOUSE_PRO = 0xc62b;
 const uint16_t PRODUCT_ID_3DCONNEXION_SPACEPILOT = 0xc625;
+const uint16_t PRODUCT_ID_3DCONNEXION_CADMAN = 0xc605;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACENAVIGATOR = 0xc626;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACENAVIGATOR_NOTEBOOK = 0xc628;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACEEXPLORER = 0xc627;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACEPILOT_PRO = 0xc629;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACETRAVELLER = 0xc623;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACEBALL_5000 = 0xc621;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACEMOUSE_CLASSIC = 0xc606;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACEMOUSE_WIRELESS = 0xc62f;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACEMOUSE_WIRELESS_CAB = 0xc62e;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACEMOUSE_PRO_WIRELESS = 0xc632;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACEMOUSE_PRO_WIRELESS_CAB = 0xc631;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACEMOUSE_PLUS = 0xc603;
+const uint16_t PRODUCT_ID_3DCONNEXION_SPACEMOUSE_ENTERPRISE = 0xc633;
 
 const uint16_t VENDOR_ID_GOOGLE = 0x18d1;
 const uint16_t PRODUCT_ID_GOOGLE_STADIA_CONTROLLER = 0x9400;
@@ -1152,17 +1166,31 @@ void apply_quirks(uint16_t vendor_id, uint16_t product_id, std::unordered_map<ui
     }
 
     // SpaceMouse says its usages are relative, but they're not.
-    if ((vendor_id == VENDOR_ID_3DCONNEXION &&
-            ((product_id == PRODUCT_ID_3DCONNEXION_SPACEMOUSE_COMPACT &&
-                 len == sizeof(spacemouse_compact_descriptor) &&
-                 !memcmp(report_descriptor, spacemouse_compact_descriptor, len)) ||
-                (product_id == PRODUCT_ID_3DCONNEXION_SPACEMOUSE_PRO &&
-                    len == sizeof(spacemouse_pro_descriptor) &&
-                    !memcmp(report_descriptor, spacemouse_pro_descriptor, len)))) ||
-        (vendor_id == VENDOR_ID_LOGITECH &&
-            product_id == PRODUCT_ID_3DCONNEXION_SPACEPILOT &&
-            len == sizeof(spacepilot_descriptor) &&
-            !memcmp(report_descriptor, spacepilot_descriptor, len))) {
+    if (vendor_id == VENDOR_ID_3DCONNEXION &&
+        ((product_id == PRODUCT_ID_3DCONNEXION_SPACEMOUSE_COMPACT &&
+             len == sizeof(spacemouse_compact_descriptor) &&
+             !memcmp(report_descriptor, spacemouse_compact_descriptor, len)) ||
+            (product_id == PRODUCT_ID_3DCONNEXION_SPACEMOUSE_PRO &&
+                len == sizeof(spacemouse_pro_descriptor) &&
+                !memcmp(report_descriptor, spacemouse_pro_descriptor, len)))) {
+        usage_map[1][0x00010030].is_relative = false;
+        usage_map[1][0x00010031].is_relative = false;
+        usage_map[1][0x00010032].is_relative = false;
+        usage_map[2][0x00010033].is_relative = false;
+        usage_map[2][0x00010034].is_relative = false;
+        usage_map[2][0x00010035].is_relative = false;
+    }
+
+    // Try to catch all other SpaceMouse models.
+    if (((vendor_id == VENDOR_ID_3DCONNEXION) || (vendor_id = 0x046d)) &&
+        usage_map.count(1) &&
+        usage_map.count(2) &&
+        usage_map[1].count(0x00010030) &&
+        usage_map[1].count(0x00010031) &&
+        usage_map[1].count(0x00010032) &&
+        usage_map[2].count(0x00010033) &&
+        usage_map[2].count(0x00010034) &&
+        usage_map[2].count(0x00010035)) {
         usage_map[1][0x00010030].is_relative = false;
         usage_map[1][0x00010031].is_relative = false;
         usage_map[1][0x00010032].is_relative = false;

--- a/firmware/src/remapper.cc
+++ b/firmware/src/remapper.cc
@@ -1290,9 +1290,9 @@ void process_mapping(bool auto_repeat) {
                 }
             }
             // we don't currently have any absolute usages that can be negative
-            if ((value < 0) && !register_target) {
-                value = 0;
-            }
+            // if ((value < 0) && !register_target) {
+            //     value = 0;
+            // }
             if (register_target) {
                 value *= 1000;
             }
@@ -1300,9 +1300,9 @@ void process_mapping(bool auto_repeat) {
                 for (auto const& out_usage_def : rev_map.our_usages) {
                     if (out_usage_def.array_count == 0) {
                         uint32_t effective_value = value;
-                        if ((out_usage_def.size < 32) && (effective_value > ((1 << out_usage_def.size) - 1))) {
-                            effective_value = (1 << out_usage_def.size) - 1;
-                        }
+                        // if ((out_usage_def.size < 32) && (effective_value > ((1 << out_usage_def.size) - 1))) {
+                        //     effective_value = (1 << out_usage_def.size) - 1;
+                        // }
                         put_bits(out_usage_def.data, out_usage_def.len, out_usage_def.bitpos, out_usage_def.size, effective_value);
                     } else {  // array range
                         for (int i = 0; i < out_usage_def.array_count; i++) {
@@ -1391,12 +1391,23 @@ void process_mapping(bool auto_repeat) {
         }
     }
 
-    for (unsigned int i = 0; i < report_ids.size(); i++) {  // XXX what order should we go in? maybe keyboard first so that mappings to ctrl-left click work as expected?
+    bool reports_to_send[MAX_INPUT_REPORT_ID + 1];
+
+    if (our_descriptor->needs_to_be_sent != nullptr) {
+        our_descriptor->needs_to_be_sent(reports, prev_reports, report_sizes, reports_to_send, frame_counter);
+    } else {
+        for (unsigned int i = 0; i < report_ids.size(); i++) {
+            uint8_t report_id = report_ids[i];
+            reports_to_send[report_id] = needs_to_be_sent(report_id);
+        }
+    }
+
+    for (unsigned int i = 0; i < report_ids.size(); i++) {
         uint8_t report_id = report_ids[i];
         if (our_descriptor->sanitize_report != nullptr) {
             our_descriptor->sanitize_report(report_id, reports[report_id], report_sizes[report_id]);
         }
-        if (needs_to_be_sent(report_id)) {
+        if (reports_to_send[report_id]) {
             if (or_items == OR_BUFSIZE) {
                 printf("overflow!\n");
                 break;
@@ -1777,6 +1788,10 @@ void rlencode(const std::set<uint64_t>& usage_ranges, std::vector<usage_rle_t>& 
 }
 
 bool should_scale_input(const usage_def_t& their_usage) {
+    if (our_descriptor_number == 6) {
+        return false;  // XXX
+    }
+
     if ((their_usage.size == 1) ||
         (their_usage.is_relative) ||
         ((their_usage.logical_minimum == 0) && (their_usage.logical_maximum == 255)) ||
@@ -1973,6 +1988,16 @@ void parse_our_descriptor() {
         boot_protocol_keyboard ? boot_kb_report_descriptor : our_descriptor->descriptor,
         boot_protocol_keyboard ? boot_kb_report_descriptor_length : our_descriptor->descriptor_length);
 
+    // XXX
+    if (our_descriptor_number == 6) {
+        our_usages[1][0x00010030].is_relative = false;
+        our_usages[1][0x00010031].is_relative = false;
+        our_usages[1][0x00010032].is_relative = false;
+        our_usages[2][0x00010033].is_relative = false;
+        our_usages[2][0x00010034].is_relative = false;
+        our_usages[2][0x00010035].is_relative = false;
+    }
+
     for (auto const& [report_id, size] : report_sizes_map[ReportType::INPUT]) {
         report_sizes[report_id] = size;
         reports[report_id] = new uint8_t[size];
@@ -1986,6 +2011,8 @@ void parse_our_descriptor() {
 
         report_ids.push_back(report_id);
     }
+
+    std::sort(report_ids.begin(), report_ids.end());
 
     std::set<uint64_t> our_usage_ranges_set;
     for (auto const& [report_id, usage_map] : our_usages) {

--- a/firmware/src/tinyusb_stuff.cc
+++ b/firmware/src/tinyusb_stuff.cc
@@ -113,15 +113,18 @@ const uint8_t* configuration_descriptors[] = {
 char const* string_desc_arr[] = {
     (const char[]){ 0x09, 0x04 },  // 0: is supported language is English (0x0409)
 
+/*
 #ifdef PICO_RP2350
     "RP2350",  // 1: Manufacturer
 #else
     "RP2040",  // 1: Manufacturer
 #endif
     "HID Remapper XXXX",  // 2: Product
-//Test this
-    // "3Dconnexion",                 // 1: Manufacturer
-    // "SpaceMouse Pro",              // 2: Product
+*/
+
+//required for SpaceMouse driver
+    "3Dconnexion",                 // 1: Manufacturer
+    "SpaceMouse Pro",              // 2: Product
 };
 
 // Invoked when received GET DEVICE DESCRIPTOR

--- a/firmware/src/tinyusb_stuff.cc
+++ b/firmware/src/tinyusb_stuff.cc
@@ -93,6 +93,12 @@ const uint8_t configuration_descriptor5[] = {
     TUD_HID_DESCRIPTOR(1, 0, HID_ITF_PROTOCOL_NONE, config_report_descriptor_length, 0x83, CFG_TUD_HID_EP_BUFSIZE, 1),
 };
 
+const uint8_t configuration_descriptor6[] = {
+    TUD_CONFIG_DESCRIPTOR(1, 2, 0, TUD_CONFIG_DESC_LEN + TUD_HID_DESC_LEN + TUD_HID_DESC_LEN, 0, 100),
+    TUD_HID_DESCRIPTOR(0, 0, HID_ITF_PROTOCOL_KEYBOARD, our_descriptors[6].descriptor_length, 0x81, CFG_TUD_HID_EP_BUFSIZE, 1),
+    TUD_HID_DESCRIPTOR(1, 0, HID_ITF_PROTOCOL_NONE, config_report_descriptor_length, 0x83, CFG_TUD_HID_EP_BUFSIZE, 1),
+};
+
 const uint8_t* configuration_descriptors[] = {
     configuration_descriptor0,
     configuration_descriptor1,
@@ -100,16 +106,22 @@ const uint8_t* configuration_descriptors[] = {
     configuration_descriptor3,
     configuration_descriptor4,
     configuration_descriptor5,
+    configuration_descriptor6,
 };
 
+// XXX make it customizable per emulated device type
 char const* string_desc_arr[] = {
     (const char[]){ 0x09, 0x04 },  // 0: is supported language is English (0x0409)
+
 #ifdef PICO_RP2350
     "RP2350",  // 1: Manufacturer
 #else
     "RP2040",  // 1: Manufacturer
 #endif
     "HID Remapper XXXX",  // 2: Product
+//Test this
+    // "3Dconnexion",                 // 1: Manufacturer
+    // "SpaceMouse Pro",              // 2: Product
 };
 
 // Invoked when received GET DEVICE DESCRIPTOR
@@ -173,12 +185,12 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
             _desc_str[1 + i] = str[i];
         }
 
-        if (index == 2) {
-            uint64_t unique_id = get_unique_id();
-            for (uint8_t i = 0; i < 4; i++) {
-                _desc_str[1 + chr_count - 4 + i] = id_chars[(unique_id >> (15 - i * 5)) & 0x1F];
-            }
-        }
+        // if (index == 2) {
+        //     uint64_t unique_id = get_unique_id();
+        //     for (uint8_t i = 0; i < 4; i++) {
+        //         _desc_str[1 + chr_count - 4 + i] = id_chars[(unique_id >> (15 - i * 5)) & 0x1F];
+        //     }
+        // }
     }
 
     // first byte is length (including header), second byte is string type

--- a/firmware/src/tinyusb_stuff.cc
+++ b/firmware/src/tinyusb_stuff.cc
@@ -109,22 +109,15 @@ const uint8_t* configuration_descriptors[] = {
     configuration_descriptor6,
 };
 
-// XXX make it customizable per emulated device type
 char const* string_desc_arr[] = {
     (const char[]){ 0x09, 0x04 },  // 0: is supported language is English (0x0409)
 
-/*
 #ifdef PICO_RP2350
     "RP2350",  // 1: Manufacturer
 #else
     "RP2040",  // 1: Manufacturer
 #endif
     "HID Remapper XXXX",  // 2: Product
-*/
-
-//required for SpaceMouse driver
-    "3Dconnexion",                 // 1: Manufacturer
-    "SpaceMouse Pro",              // 2: Product
 };
 
 // Invoked when received GET DEVICE DESCRIPTOR
@@ -176,7 +169,14 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
         if (!(index < sizeof(string_desc_arr) / sizeof(string_desc_arr[0])))
             return NULL;
 
-        const char* str = string_desc_arr[index];
+        const char* str = NULL;
+        if (index == 1 && our_descriptor->manufacturer[0] != '\0') {
+        str = our_descriptor->manufacturer;
+        } else if (index == 2 && our_descriptor->product[0] != '\0') {
+        str = our_descriptor->product;
+        } else {
+        str = string_desc_arr[index];
+        }
 
         // Cap at max char
         chr_count = strlen(str);
@@ -188,12 +188,12 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
             _desc_str[1 + i] = str[i];
         }
 
-        // if (index == 2) {
-        //     uint64_t unique_id = get_unique_id();
-        //     for (uint8_t i = 0; i < 4; i++) {
-        //         _desc_str[1 + chr_count - 4 + i] = id_chars[(unique_id >> (15 - i * 5)) & 0x1F];
-        //     }
-        // }
+        if (index == 2 && our_descriptor->product[0] == '\0') {
+            uint64_t unique_id = get_unique_id();
+            for (uint8_t i = 0; i < 4; i++) {
+                _desc_str[1 + chr_count - 4 + i] = id_chars[(unique_id >> (15 - i * 5)) & 0x1F];
+            }
+        }
     }
 
     // first byte is length (including header), second byte is string type


### PR DESCRIPTION
Added support for remapping a SpacePilot to a SpaceMouse Pro.
Fully working setup, bar buttons 5-6 & sensitivity not being mapped.

Outstanding issues that would prevent merging to main in its current state:
Vendor and Model name need to be set correctly to be picked up by driver
https://github.com/jfedor2/hid-remapper/compare/master...alextrical:SpacePilot-to-SpaceMousePro?expand=1#diff-dfa8139f3d20c0fa167aa638ddfbe1b1bf28d44d67dd7437a73b3f4631eaca89R126-R127:~:text=%223Dconnexion%22,//%202%3A%20Product

Ideally this should be set in "const our_descriptor_def_t our_descriptors[] = {"
But I don't know if this is possible currently 
