### PR TITLE
gh-actions: update actions to v6

### DIFF
--- a/.github/workflows/build-nrf52.yml
+++ b/.github/workflows/build-nrf52.yml
@@ -15,13 +15,13 @@ jobs:
       matrix:
         board: ["adafruit_feather_nrf52840", "seeed_xiao_nrf52840"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build
         run: |
           docker run -v $PWD:/workdir/project -w /workdir/project/firmware-bluetooth nordicplayground/nrfconnect-sdk:v2.2-branch \
             west build -b ${{ matrix.board }}
           cp firmware-bluetooth/build/zephyr/remapper.uf2 firmware-bluetooth/remapper_${{ matrix.board }}.uf2
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: artifact-${{ matrix.board }}
           path: firmware-bluetooth/remapper_${{ matrix.board }}.uf2

--- a/.github/workflows/build-rp2040.yml
+++ b/.github/workflows/build-rp2040.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Install compiler, libraries and tools
@@ -92,6 +92,6 @@ jobs:
           mv build-flatbox_rev8/remapper.uf2 artifacts/remapper_flatbox_rev8.uf2
           mv build-waveshare_rp2350_pizero/remapper.uf2 artifacts/remapper_waveshare_rp2350_pizero.uf2
         working-directory: ./firmware
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           path: firmware/artifacts/*


### PR DESCRIPTION
v4 is getting deprecated and raises warnings.
They'll be removed in June 2026.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/