### PR TITLE
Fix modifier keys for BLE keyboards without report IDs

### DIFF
--- a/firmware-bluetooth/src/main.cc
+++ b/firmware-bluetooth/src/main.cc
@@ -55,6 +55,7 @@ static const struct device* hid_dev1;  // config interface
 
 struct report_type {
     uint16_t interface;
+    uint8_t report_id;
     uint8_t len;
     uint8_t data[65];
 };
@@ -504,10 +505,10 @@ static uint8_t hogp_notify_cb(struct bt_hogp* hogp, struct bt_hogp_rep_info* rep
 
     static struct report_type buf;
     buf.interface = hogp_index(hogp) << 8;
-    buf.len = bt_hogp_rep_size(rep) + 1;
-    buf.data[0] = bt_hogp_rep_id(rep);
+    buf.report_id = bt_hogp_rep_id(rep);
+    buf.len = bt_hogp_rep_size(rep);
 
-    memcpy(buf.data + 1, data, buf.len);
+    memcpy(buf.data, data, buf.len);
     if (k_msgq_put(&report_q, &buf, K_NO_WAIT)) {
         //        printk("error in k_msg_put(report_q\n");
     }
@@ -685,6 +686,7 @@ static void int_out_ready_cb0(const struct device* dev) {
     uint32_t len;
     if (CHK(hid_int_ep_read(hid_dev0, buf.data, sizeof(buf.data), &len))) {
         buf.interface = OUR_OUT_INTERFACE;
+        buf.report_id = 0;
         buf.len = len;
         CHK(k_msgq_put(&report_q, &buf, K_NO_WAIT));
     }
@@ -927,7 +929,7 @@ int main() {
 
     while (true) {
         if (!process_pending && !k_msgq_get(&report_q, &incoming_report, K_NO_WAIT)) {
-            handle_received_report(incoming_report.data, incoming_report.len, (uint16_t) incoming_report.interface);
+            handle_received_report(incoming_report.data, incoming_report.len, (uint16_t) incoming_report.interface, incoming_report.report_id);
             process_pending = true;
         }
         if (atomic_test_and_clear_bit(tick_pending, 0)) {


### PR DESCRIPTION
Hi! First of all, thank you for this project — the Bluetooth version of HID Remapper solved a real problem for me (using a Bluetooth keyboard with a computer where Bluetooth is not allowed).

## Problem

The Bluetooth notify callback unconditionally prepends the report ID byte to report data before passing it to `handle_received_report()`. For devices whose report map contains no `REPORT_ID` items — which is valid HID — `has_report_id_theirs` is false, so the parser reads fields starting at byte 0 of the buffer. The prepended byte shifts every field by one: the modifier bitmap always reads as 0x00, so Shift/Ctrl/Alt/GUI are silently dropped, while array-style keycodes still (mostly) work, which makes this easy to miss.

## Fix

Pass the report ID through the existing `external_report_id` parameter instead of prepending it to the data. Devices whose report maps do use report IDs keep the exact same behavior. This also fixes a one-byte overread in the notify callback memcpy (`rep_size + 1` bytes were copied from a `rep_size`-sized buffer).

## Tested with

Cornix split keyboard (RMK firmware) — it sends an unnumbered 8-byte boot-style keyboard report over HOGP. Modifiers were dead before this change and fully working after; regression-checked that regular keys still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)